### PR TITLE
Use new `scorify/schema` for config handing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/scorify/check-template
 
-go 1.21.6
+go 1.22.6
+
+toolchain go1.22.7
+
+require github.com/scorify/schema v0.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/scorify/schema v0.0.0 h1:S+YUZAdZzlFOPvQH/hOXr5Q7zMTH+9RjgHB8H1/0HWM=
+github.com/scorify/schema v0.0.0/go.mod h1:Cf41cz40/NtwwwDKJrx9JSQ5LQ1eV4vrwZVocFgy8Uo=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -8,8 +8,8 @@ import (
 
 // Schema is a custom defined struct that will hold the check configuration
 type Schema struct {
-	Target string `json:"target"` // Make sure to use the json tags to define the key in the config
-	Port   int    `json:"port"`
+	Target string `key:"target"` // Make sure to use the scorify tags to define the key in the config
+	Port   int    `key:"port"`
 
 	// Add any additional fields that you want to pass in as config
 }

--- a/main.go
+++ b/main.go
@@ -27,7 +27,5 @@ func Run(ctx context.Context, config string) error {
 
 	// Custom logic to run the check
 
-	fmt.Println("Running check with target:", schema.Target, "and port:", schema.Port)
-
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -1,9 +1,9 @@
-package check_template
+package main
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
+
+	"github.com/scorify/schema"
 )
 
 // Schema is a custom defined struct that will hold the check configuration
@@ -17,10 +17,10 @@ type Schema struct {
 // Run is the function that will get called to run an instance of a check
 func Run(ctx context.Context, config string) error {
 	// Define a new Schema
-	schema := Schema{}
+	conf := Schema{}
 
 	// Unmarshal the config to the Schema
-	err := json.Unmarshal([]byte(config), &schema)
+	err := schema.Unmarshal([]byte(config), &conf)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
use `key` instead of `json`

remove print statement

move over to using `scorify/schema` for (un)marshaling

`go mod tidy`